### PR TITLE
Duplicating storage_master_node (it is both LogicModule and client)

### DIFF
--- a/scripts/storage_init.sh
+++ b/scripts/storage_init.sh
@@ -60,7 +60,9 @@ if [ "${network}" == "infiniband" ]; then
 fi
 
 #----------------------------------------- SLURM -------------------------------------------------
-COMPSS_HOSTS="$storage_master_node $worker_nodes"
+# Note that $storage_master_node is used both as a client and for the LogicModule service.
+# Check dataclaysrv command for further information on the hosts semantics.
+COMPSS_HOSTS="$storage_master_node $storage_master_node $worker_nodes"
 JOB_HOSTS=($(echo $COMPSS_HOSTS | tr " " "\n"))
 HOSTS=""
 # Get hosts and add infiniband suffix if needed


### PR DESCRIPTION
dataclaysrv expects:

ClientHost LogicModuleHost DataServiceHost1 [DataServiceHost2 ...]

But that does not match what COMPSs uses. COMPSs has the concept of "Storage Master Node" where both the COMPSs Master and LogicModule are started. The client should also be there, as it is the node used for all those operations.

This PR should fix the mismatch between `storage_init.sh` and `dataclaysrv` (just by duplicating storage_master_node, which serves both purposes).